### PR TITLE
feat: Add selectable OpenAI Realtime API model in voice chat settings

### DIFF
--- a/src/app/api/chat/openai-realtime/route.ts
+++ b/src/app/api/chat/openai-realtime/route.ts
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest) {
       return new Response("Unauthorized", { status: 401 });
     }
 
-    const { voice, mentions, agentId } = (await request.json()) as {
+    const { model, voice, mentions, agentId } = (await request.json()) as {
       model: string;
       voice: string;
       agentId?: string;
@@ -102,7 +102,7 @@ export async function POST(request: NextRequest) {
       },
 
       body: JSON.stringify({
-        model: "gpt-4o-realtime-preview",
+        model: model || "gpt-4o-realtime-preview",
         voice: voice || "alloy",
         input_audio_transcription: {
           model: "whisper-1",

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -103,7 +103,8 @@ const initialState: AppState = {
     options: {
       provider: "openai",
       providerOptions: {
-        model: OPENAI_VOICE["Alloy"],
+        voice: OPENAI_VOICE.Alloy,
+        model: "gpt-4o-realtime-preview",
       },
     },
   },

--- a/src/components/chat-bot-voice.tsx
+++ b/src/components/chat-bot-voice.tsx
@@ -21,6 +21,7 @@ import {
   MessageSquareMoreIcon,
   WrenchIcon,
   ChevronRight,
+  BrainCircuitIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -66,6 +67,12 @@ const prependTools: EnabledTools[] = [
     })),
   },
 ];
+
+export const OPENAI_REALTIME_MODELS = {
+  "GPT-4o Realtime": "gpt-4o-realtime-preview",
+  "GPT Realtime": "gpt-realtime",
+  "GPT Realtime Mini": "gpt-realtime-mini",
+} as const;
 
 export function ChatBotVoice() {
   const t = useTranslations("Chat");
@@ -363,8 +370,52 @@ export function ChatBotVoice() {
                           className="flex items-center gap-2 cursor-pointer"
                           icon=""
                         >
+                          <BrainCircuitIcon className="size-3.5" />
+                          Model
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent>
+                            {Object.entries(OPENAI_REALTIME_MODELS).map(
+                              ([key, value]) => (
+                                <DropdownMenuItem
+                                  className="cursor-pointer flex items-center justify-between"
+                                  onClick={() =>
+                                    appStoreMutate({
+                                      voiceChat: {
+                                        ...voiceChat,
+                                        options: {
+                                          ...voiceChat.options,
+                                          providerOptions: {
+                                            ...voiceChat.options
+                                              .providerOptions,
+                                            model: value,
+                                          },
+                                        },
+                                      },
+                                    })
+                                  }
+                                  key={key}
+                                >
+                                  {key}
+
+                                  {value ===
+                                    voiceChat.options.providerOptions
+                                      ?.model && (
+                                    <CheckIcon className="size-3.5" />
+                                  )}
+                                </DropdownMenuItem>
+                              ),
+                            )}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger
+                          className="flex items-center gap-2 cursor-pointer"
+                          icon=""
+                        >
                           <OpenAIIcon className="size-3.5 stroke-none fill-foreground" />
-                          Open AI
+                          Voice
                         </DropdownMenuSubTrigger>
                         <DropdownMenuPortal>
                           <DropdownMenuSubContent>
@@ -377,8 +428,10 @@ export function ChatBotVoice() {
                                       voiceChat: {
                                         ...voiceChat,
                                         options: {
-                                          provider: "openai",
+                                          ...voiceChat.options,
                                           providerOptions: {
+                                            ...voiceChat.options
+                                              .providerOptions,
                                             voice: value,
                                           },
                                         },


### PR DESCRIPTION
## Summary
This PR adds the ability for users to select different OpenAI Realtime API models directly from the voice chat settings UI, replacing the previously hard-coded `gpt-4o-realtime-preview` model.

## Motivation
Users were unable to configure which OpenAI Realtime model to use for voice conversations. The model was hard-coded, preventing users from trying newer models like `gpt-realtime` or `gpt-realtime-mini` which may offer better performance or cost benefits.

## Changes Made
- **Backend (`route.ts`)**: Modified to accept and use the `model` parameter from request body instead of hard-coded value
- **State Management (`store/index.ts`)**: Updated voice chat state to properly store both `voice` and `model` in `providerOptions`
- **UI (`chat-bot-voice.tsx`)**: Added new "Model" selector dropdown in voice chat settings with three options:
  - GPT-4o Realtime (`gpt-4o-realtime-preview`) - default
  - GPT Realtime (`gpt-realtime`)
  - GPT Realtime Mini (`gpt-realtime-mini`)
- **UI Enhancement**: Renamed voice selector from "Open AI" to "Voice" for better clarity

## Features
✅ Model selection persists across sessions
✅ Independent from text chat model selection
✅ Visual indicator (checkmark) shows currently selected model
✅ Smooth settings UI with brain icon for model selector
✅ Fallback to default model if none specified

## Testing
1. Open voice chat by clicking the voice icon
2. Click the settings icon (gear) in the top right
3. Select "Model" to see available OpenAI Realtime models
4. Choose a different model
5. Start a voice conversation - it should use the selected model
6. Close and reopen voice chat - selection should persist

## Files Changed
- `src/app/api/chat/openai-realtime/route.ts`
- `src/app/store/index.ts`
- `src/components/chat-bot-voice.tsx`

## Breaking Changes
None - this is a backward compatible enhancement with sensible defaults.

<img width="229" height="144" alt="image" src="https://github.com/user-attachments/assets/b3c69c11-92b7-450b-ac97-1be9cc9b8c4d" />
<img width="391" height="148" alt="image" src="https://github.com/user-attachments/assets/e91a45b6-7d68-4793-bb97-d45c45d5b34b" />
<img width="357" height="338" alt="image" src="https://github.com/user-attachments/assets/768d2756-9ae7-4aa1-b104-a7f841d6a37a" />
