### PR TITLE
feat: inject available agents into system prompt

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -42,6 +42,7 @@ import {
 } from "./shared.chat";
 import {
   rememberAgentAction,
+  rememberAvailableAgentsAction,
   rememberMcpServerCustomizationsAction,
 } from "./actions";
 import { getSession } from "auth/server";
@@ -269,8 +270,18 @@ export async function POST(request: Request) {
           .map((v) => filterMcpServerCustomizations(MCP_TOOLS!, v))
           .orElse({});
 
+        // Fetch available agents only when no agent is selected
+        const availableAgents = !agent
+          ? await rememberAvailableAgentsAction(session.user.id)
+          : undefined;
+
         const systemPrompt = mergeSystemPrompt(
-          buildUserSystemPrompt(session.user, userPreferences, agent),
+          buildUserSystemPrompt(
+            session.user,
+            userPreferences,
+            agent,
+            availableAgents,
+          ),
           buildMcpServerCustomizationsSystemPrompt(mcpServerCustomizations),
           !supportToolCall && buildToolCallUnsupportedModelSystemPrompt,
         );

--- a/src/lib/ai/prompts.test.ts
+++ b/src/lib/ai/prompts.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { buildUserSystemPrompt } from "./prompts";
+import { AgentSummary, Agent } from "app-types/agent";
+
+describe("buildUserSystemPrompt", () => {
+  const mockAvailableAgents: AgentSummary[] = [
+    {
+      id: "agent-1",
+      name: "Code Reviewer",
+      description: "Reviews code for best practices",
+      userId: "user-1",
+      visibility: "private",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: "agent-2",
+      name: "Technical Writer",
+      description: "Writes documentation",
+      userId: "user-1",
+      visibility: "public",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: "agent-3",
+      name: "Simple Agent",
+      // No description
+      userId: "user-1",
+      visibility: "private",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ];
+
+  const mockSelectedAgent: Agent = {
+    id: "selected-agent",
+    name: "Selected Agent",
+    description: "The currently selected agent",
+    userId: "user-1",
+    visibility: "private",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    instructions: {
+      role: "Testing Expert",
+      systemPrompt: "You are a testing expert.",
+    },
+  };
+
+  describe("available agents section", () => {
+    it("should include available agents when no agent is selected", () => {
+      const prompt = buildUserSystemPrompt(
+        undefined,
+        undefined,
+        undefined,
+        mockAvailableAgents,
+      );
+
+      expect(prompt).toContain("<available_agents>");
+      expect(prompt).toContain("</available_agents>");
+      expect(prompt).toContain(
+        "**Code Reviewer**: Reviews code for best practices",
+      );
+      expect(prompt).toContain("**Technical Writer**: Writes documentation");
+      expect(prompt).toContain("**Simple Agent**");
+      expect(prompt).toContain("typing @ followed by the agent name");
+      expect(prompt).toContain("from the tools menu");
+      expect(prompt).toContain("agents menu in the sidebar");
+    });
+
+    it("should not include available agents section when an agent is selected", () => {
+      const prompt = buildUserSystemPrompt(
+        undefined,
+        undefined,
+        mockSelectedAgent,
+        mockAvailableAgents,
+      );
+
+      expect(prompt).not.toContain("<available_agents>");
+      expect(prompt).not.toContain("</available_agents>");
+      // Should include the selected agent's instructions instead
+      expect(prompt).toContain("Selected Agent");
+      expect(prompt).toContain("Testing Expert");
+    });
+
+    it("should not include available agents section when list is empty", () => {
+      const prompt = buildUserSystemPrompt(undefined, undefined, undefined, []);
+
+      expect(prompt).not.toContain("<available_agents>");
+      expect(prompt).not.toContain("</available_agents>");
+    });
+
+    it("should not include available agents section when list is undefined", () => {
+      const prompt = buildUserSystemPrompt(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      expect(prompt).not.toContain("<available_agents>");
+      expect(prompt).not.toContain("</available_agents>");
+    });
+
+    it("should handle agents without descriptions", () => {
+      const prompt = buildUserSystemPrompt(undefined, undefined, undefined, [
+        {
+          id: "no-desc",
+          name: "No Description Agent",
+          userId: "user-1",
+          visibility: "private",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      expect(prompt).toContain("**No Description Agent**");
+      // Should not have a colon after the name when no description
+      expect(prompt).not.toContain("**No Description Agent**:");
+    });
+  });
+});

--- a/src/lib/cache/cache-keys.ts
+++ b/src/lib/cache/cache-keys.ts
@@ -4,4 +4,5 @@ export const CacheKeys = {
   mcpServerCustomizations: (userId: string) =>
     `mcp-server-customizations-${userId}`,
   agentInstructions: (agent: string) => `agent-instructions-${agent}`,
+  availableAgents: (userId: string) => `available-agents-${userId}`,
 };


### PR DESCRIPTION
## Summary
- When no agent is selected, the system prompt now includes a list of available agents with their names and descriptions
- This allows the AI to suggest relevant agents when the user's request would benefit from specialized expertise
- Users are informed they can select agents via @mention, tools menu, or sidebar

## Changes
- Added `rememberAvailableAgentsAction` with 5-minute cache in `actions.ts`
- Updated `buildUserSystemPrompt` to accept optional `availableAgents` parameter
- Added `<available_agents>` section to prompt when no agent is selected
- Added cache key for available agents
- Added unit tests for the new functionality

## Test plan
- [x] Types check passes
- [x] Lint passes
- [x] Unit tests pass (5 new tests for prompt builder)
- [ ] Manual test: Start a new chat without an agent, verify AI can suggest agents
- [ ] Manual test: Start a chat with an agent selected, verify agents section is not included

🤖 Generated with [Claude Code](https://claude.com/claude-code)